### PR TITLE
Corrected length kwargs

### DIFF
--- a/wtformsparsleyjs/core.py
+++ b/wtformsparsleyjs/core.py
@@ -92,7 +92,7 @@ def _length_kwargs(kwargs, vali):
     default_number = -1
 
     if vali.max != default_number and vali.min != default_number:
-        kwargs[u'data-parsley-rangelength'] = u'[' + str(vali.min) + u',' + str(vali.max) + u']'
+        kwargs[u'data-parsley-length'] = u'[' + str(vali.min) + u',' + str(vali.max) + u']'
     else:
         if vali.max == default_number:
             kwargs[u'data-parsley-minlength'] = str(vali.min)


### PR DESCRIPTION
johannes-gehrs repo seems to be dead, and this repo is much more up to date so thought I may as well pull request here.

As can be seen in the parsley docs (http://parsleyjs.org/doc/index.html#psly-validators-list) data-parsley-length should be used not data-parsley-rangelength
